### PR TITLE
Add tensordataset example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,23 @@ python -m app.main_distributed \
   --account my_account --qos=my_qos
 ```
 
+### TensorDataset Example
+
+Use the `tensordataset` option to pretrain on frames stored as tensors.
+The [configs/train/tensor64x128.yaml](configs/train/tensor64x128.yaml) configuration uses 64x128 crops. Launch locally with:
+```bash
+python -m app.main --fname configs/train/tensor64x128.yaml 
+  --devices cuda:0
+```
+for distributed training:
+```bash
+python -m app.main_distributed 
+  --fname configs/train/tensor64x128.yaml 
+  --time 6000 
+  --account my_account --qos=my_qos
+```
+
+
 ### Postraining
 
 Post-training of the action-conditioned model, starting from the pretrained VJEPA 2 backbone, also follows a similar interface, and can be run locally or distributed using [this config](configs/train/vitg16/droid-256px-8f.yaml).

--- a/configs/train/tensor64x128.yaml
+++ b/configs/train/tensor64x128.yaml
@@ -1,0 +1,53 @@
+app: vjepa
+nodes: 1
+tasks_per_node: 1
+cpus_per_task: 4
+mem_per_gpu: 32G
+folder: /your_folder/tensor64x128
+
+data:
+  dataset_type: tensordataset
+  datasets:
+    - /your_tensor_dataset/path.csv
+  batch_size: 32
+  crop_size: [64, 128]
+  patch_size: 16
+  dataset_fpcs:
+    - 1
+  tubelet_size: 2
+  fps: 4
+  num_workers: 4
+  pin_mem: true
+
+data_aug:
+  auto_augment: false
+  motion_shift: false
+  random_resize_aspect_ratio:
+    - 0.75
+    - 1.35
+  random_resize_scale:
+    - 0.3
+    - 1.0
+  reprob: 0.0
+
+loss:
+  loss_exp: 1.0
+meta:
+  dtype: bfloat16
+  eval_freq: 100
+  save_every_freq: 25
+  seed: 239
+  use_sdpa: true
+model:
+  model_name: vit_giant_xformers
+  pred_depth: 12
+  pred_embed_dim: 384
+  pred_num_heads: 12
+  uniform_power: true
+  use_activation_checkpointing: true
+  use_rope: true
+optimization:
+  epochs: 10
+  lr: 0.0001
+  weight_decay: 0.04
+  warmup: 5


### PR DESCRIPTION
## Summary
- add sample config for `tensordataset` with 64x128 crops
- document how to launch training with the new config

## Testing
- `pip install -q -r requirements-test.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b3d4823b88328ac7a83a8480e195d