### PR TITLE
Handle valid patch masking

### DIFF
--- a/app/vjepa/train.py
+++ b/app/vjepa/train.py
@@ -29,7 +29,7 @@ from torch.nn.parallel import DistributedDataParallel
 from app.vjepa.transforms import make_transforms
 from app.vjepa.utils import init_opt, init_video_model, load_checkpoint
 from src.datasets.data_manager import init_data
-from src.masks.multiseq_multiblock3d import MaskCollator
+from src.masks.multiseq_multiblock3d import TensorMaskCollator
 from src.masks.utils import apply_masks
 from src.utils.distributed import init_distributed
 from src.utils.logging import AverageMeter, CSVLogger, get_logger, gpu_timer
@@ -216,7 +216,7 @@ def main(args, resume_preempt=False):
         target_encoder.compile()
         predictor.compile()
 
-    mask_collator = MaskCollator(
+    mask_collator = TensorMaskCollator(
         cfgs_mask=cfgs_mask,
         dataset_fpcs=dataset_fpcs,
         crop_size=crop_size,
@@ -250,6 +250,8 @@ def main(args, resume_preempt=False):
         num_workers=num_workers,
         pin_mem=pin_mem,
         log_dir=None,
+        patch_size=patch_size,
+        tubelet_size=tubelet_size,
     )
     try:
         _dlen = len(unsupervised_loader)
@@ -387,7 +389,7 @@ def main(args, resume_preempt=False):
                         raise e
 
             for _fpc_sample in sample:
-                bs, fpc = _fpc_sample[0][-1][0].size()
+                bs, fpc = _fpc_sample[0][2][0].size()
                 mask_meters[fpc].update(bs / batch_size)
 
             def load_clips():

--- a/src/datasets/data_manager.py
+++ b/src/datasets/data_manager.py
@@ -38,6 +38,8 @@ def init_data(
     persistent_workers=False,
     deterministic=True,
     log_dir=None,
+    patch_size=16,
+    tubelet_size=2,
 ):
     if data.lower() == "imagenet":
         from src.datasets.imagenet1k import make_imagenet1k
@@ -85,6 +87,8 @@ def init_data(
             rank=rank,
             deterministic=deterministic,
             log_dir=log_dir,
+            patch_size=patch_size,
+            tubelet_size=tubelet_size,
         )
 
     return (data_loader, dist_sampler)

--- a/tests/datasets/test_tensor_mask_collator.py
+++ b/tests/datasets/test_tensor_mask_collator.py
@@ -1,0 +1,35 @@
+import torch
+from torch.utils.data import DataLoader
+
+from src.masks.multiseq_multiblock3d import TensorMaskCollator
+
+class DummyDataset(torch.utils.data.Dataset):
+    def __len__(self):
+        return 1
+
+    def __getitem__(self, idx):
+        clip = torch.zeros(3, 4, 32, 32)
+        clip[:, :2, :16, :16] = 1.0
+        valid = torch.tensor([0], dtype=torch.int64)
+        return [clip], 0, [torch.arange(4)], [valid]
+
+def test_masks_respect_valid_indices():
+    cfg = [{
+        "spatial_scale": (0.5, 0.5),
+        "temporal_scale": (1.0, 1.0),
+        "aspect_ratio": (1.0, 1.0),
+        "num_blocks": 1,
+    }]
+    collator = TensorMaskCollator(
+        cfgs_mask=cfg,
+        dataset_fpcs=[4],
+        crop_size=(32, 32),
+        patch_size=(16, 16),
+        tubelet_size=2,
+    )
+    loader = DataLoader(DummyDataset(), batch_size=1, collate_fn=collator)
+    batch = next(iter(loader))
+    collated_batch, masks_encs, masks_preds = batch[0]
+    valid = collated_batch[3][0]
+    for tensor in masks_encs + masks_preds:
+        assert set(tensor[0].tolist()).issubset(set(valid.tolist()))


### PR DESCRIPTION
## Summary
- compute valid patch indices in `VideoDataset`
- add `TensorMaskCollator` to intersect sampled masks with valid patches
- pass patch params to dataset helpers and training
- update training loop for new collator output
- test mask generator respects valid patch indices

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b3d29ee2483289fa2183e58217916